### PR TITLE
- Change Document.java to use intent instead of displaying the folder…

### DIFF
--- a/AWSCognitoSampleApp/MySampleApp/app/src/main/java/com/PocketMoodle/DocumentsFragment.java
+++ b/AWSCognitoSampleApp/MySampleApp/app/src/main/java/com/PocketMoodle/DocumentsFragment.java
@@ -1,136 +1,80 @@
 package com.PocketMoodle;
 
 
+import android.app.Activity;
+import android.content.Intent;
 import android.graphics.Color;
+import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 
-import android.os.Environment;
-import android.view.View.OnClickListener;
-import android.widget.AdapterView;
-import android.widget.AdapterView.OnItemClickListener;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
-import android.widget.ListView;
 import android.widget.TextView;
 
 /**
  * A simple {@link Fragment} subclass.
  */
-public class DocumentsFragment extends Fragment {
+public class DocumentsFragment extends Fragment implements View.OnClickListener {
 
     Button uploadButton;
-    Button backButton;
-    TextView folder;
-
-    ListView listView;
-
-    File rootDirectoryPath;
-    File currentFolder;
-    private List<String> fileList = new ArrayList<String>();
+    TextView textView;
+    private static final String TAG = "DocumentsFragment";
+    private int RESULT_CODE = 0;
 
     public DocumentsFragment() {
         // Required empty public constructor
     }
 
-
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View v = inflater.inflate(R.layout.fragment_documents, container, false);
-
-        //Get root path in android device
-        rootDirectoryPath = new File(Environment.getExternalStorageDirectory().getAbsolutePath());
-
-        // Specify the current folder to begin at root
-        currentFolder = rootDirectoryPath;
-
-        folder = (TextView)v.findViewById(R.id.folder);
-
-        // Button to display file explorer begining at root
-        backButton = (Button)v.findViewById(R.id.backParent);
-        backButton.setEnabled(false);
-
-        backButton.setOnClickListener(new Button.OnClickListener() {
-            public void onClick(View v) {
-                DirectoryFiles(currentFolder.getParentFile());            }
-        });
-
+        textView = (TextView) v.findViewById(R.id.uploadStatus);
 
         // Button to display file explorer begining at root
         uploadButton = (Button)v.findViewById(R.id.uploadDocument);
-        uploadButton.setOnClickListener(new OnClickListener(){
-
-            // When going through file explorer reclicking upload document allows u to
-            //  to go back to the file list(i.e the parent file of what u are in)
-            @Override
-            public void onClick(View v) {
-                backButton.setEnabled(true);
-                DirectoryFiles(rootDirectoryPath);
-            }});
-
-        // get ListView in fragment_document
-        listView = (ListView)v.findViewById(R.id.directorylist);
-
-        // Set on click listener to listen to the file the use chooses
-        listView.setOnItemClickListener(new OnItemClickListener(){
-
-            // When a file/directory is clicked. If a file is chosen change status message to File Selected
-            // When a directory is clicked. Go into the directory to view files
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view,
-                                    int position, long id) {
-
-                File selected = new File(fileList.get(position));
-                if(selected.isDirectory()){
-                    DirectoryFiles(selected);
-                }else {
-                    setUploadStatusMessage("Status: File Selected");
-                    backButton.setEnabled(false);
-                }
-
-            }});
+        uploadButton.setOnClickListener(this);
 
         return v;
-
     }
 
-    public void DirectoryFiles(File file){
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
 
-        // Only allow the user to go to parent directory if he is not already at the root
-        if(file.equals(rootDirectoryPath)){
-            backButton.setEnabled(false);
-        }else{
-            backButton.setEnabled(true);
+
+        // Check which request we're responding to
+        if (requestCode == RESULT_CODE) {
+            // Make sure the request was successful
+            if (resultCode == Activity.RESULT_OK) {
+
+                Uri uri = data.getData();
+                textView.setText("Status: File selected - " + uri.getPath());
+                textView.setTextColor(Color.GREEN);
+
+                // Use this data variable to get the path or whatever detail of the chosen file details you need for the api
+
+            }
         }
-
-        currentFolder = file;
-        folder.setText(file.getPath());
-
-        File[] files = file.listFiles();
-        fileList.clear();
-        for (File tempFile : files){
-            fileList.add(tempFile.getPath());
-        }
-
-        ArrayAdapter<String> directoryList
-                = new ArrayAdapter<String>(getActivity(),
-                android.R.layout.simple_list_item_1, fileList);
-        listView.setAdapter(directoryList);
     }
 
-    // Once a file is selected this method can update the Status message in fragment_add_document
-    public void setUploadStatusMessage(String uploadStatusMessage)
-    {
-        TextView textView = (TextView) getView().findViewById(R.id.uploadStatus);
-        textView.setText(uploadStatusMessage);
-        textView.setTextColor(Color.GREEN);
+    public void onClick(View v) {
+
+        if(v.getId() == R.id.uploadDocument) {
+            try {
+                Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                intent.setType("*/*");
+                startActivityForResult(Intent.createChooser(intent, "Select a Document to Upload"), RESULT_CODE);
+
+            } catch (Exception ex) {
+                // In case the intent fails display error message in log
+                Log.d(TAG, "Error accessing file explorer in class DocumentFragment");
+            }
+
+        }
     }
 }

--- a/AWSCognitoSampleApp/MySampleApp/app/src/main/java/com/PocketMoodle/MainActivity.java
+++ b/AWSCognitoSampleApp/MySampleApp/app/src/main/java/com/PocketMoodle/MainActivity.java
@@ -241,5 +241,9 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
     protected void onPause() {
         super.onPause();
     }
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data){
+        super.onActivityResult(requestCode,resultCode,data);
+    }
 
 }

--- a/AWSCognitoSampleApp/MySampleApp/app/src/main/res/layout/fragment_documents.xml
+++ b/AWSCognitoSampleApp/MySampleApp/app/src/main/res/layout/fragment_documents.xml
@@ -36,28 +36,6 @@
             android:layout_margin="5dp"
             android:text="@string/upload_document"/>
 
-        <Button
-            android:id="@+id/backParent"
-            android:layout_width="100dp"
-            android:layout_height="35dp"
-            android:drawableTop="@drawable/ic_arrow_24dp"
-            android:layout_margin="5dp"
-            android:layout_alignParentTop="true"
-            android:layout_alignParentRight="true"
-            android:layout_alignParentEnd="true" />
-
     </RelativeLayout>
-
-    <TextView
-        android:id="@+id/folder"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
-    <ListView
-        android:id="@+id/directorylist"
-        android:layout_width="fill_parent"
-        android:layout_height="150dp"
-        android:padding="10dp"
-        />
 
 </LinearLayout>


### PR DESCRIPTION
…s directly onto the fragment

- Allow user to select any time of files through a file chooser available on their device
- Remove back button and list in fragment_document.xml (No longer needed)

It is possible to specify the type of document i.e "file/*" the user is allowed to pick

So if you have a file explorer on your device it will directly open it and from their you can go to local storage, google drive, photo, etc. 

![image](https://cloud.githubusercontent.com/assets/25251945/23448785/0085f81a-fe21-11e6-9b95-c22382e56b72.png)

Otherwise you will be prompted to choose another service on your device

![image](https://cloud.githubusercontent.com/assets/25251945/23448794/104ab204-fe21-11e6-8d00-9c17d16d4ad2.png)

Solution to issue #67 